### PR TITLE
encode value in hex

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "fix": "yarn fix:prettier && yarn fix:lint",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:lint": "eslint src --ext .ts --fix",
+    "pretest": "hardhat compile",
     "test": "hardhat test",
     "test:watch": "mocha -w"
   },

--- a/src/decodeMulti.ts
+++ b/src/decodeMulti.ts
@@ -15,7 +15,7 @@ const unpack = (packed: string, startIndex: number) => {
   // then comes the uint256 value (= 64 hex digits)
   const value = BigNumber.from(
     `0x${packed.substring(startIndex + 42, startIndex + 106)}`
-  ).toString()
+  ).toHexString()
 
   // and the uint256 data length (= 64 hex digits)
   const hexDataLength = parseInt(

--- a/src/decodeSingle.ts
+++ b/src/decodeSingle.ts
@@ -107,7 +107,7 @@ export const decodeSingle = async (
         abi,
         functionSignature: fragment.format(),
         inputValues: decodeArgs(data, fragment.inputs),
-        value: BigNumber.from(value || '0').toString(),
+        value: BigNumber.from(value || '0x0').toString(),
       }
     }
   }
@@ -116,7 +116,7 @@ export const decodeSingle = async (
     type: TransactionType.raw,
     id,
     to,
-    value,
+    value: BigNumber.from(value || '0x0').toString(),
     data,
   }
 }

--- a/src/decodeSingle.ts
+++ b/src/decodeSingle.ts
@@ -25,7 +25,7 @@ export const decodeSingle = async (
 ): Promise<TransactionInput> => {
   const { to, data, value } = transaction
 
-  if (!data || data === '0x') {
+  if (!data || BigNumber.from(data).isZero()) {
     // ETH transfer
     return {
       type: TransactionType.transferFunds,
@@ -47,7 +47,7 @@ export const decodeSingle = async (
     // it's not an ERC20 transfer
   }
 
-  if (erc20TransferData && BigNumber.from(value).eq(0)) {
+  if (erc20TransferData && BigNumber.from(value).isZero()) {
     const decimals = await new Contract(to, erc20Interface, provider).decimals()
     return {
       type: TransactionType.transferFunds,
@@ -69,7 +69,7 @@ export const decodeSingle = async (
     // it's not an ERC721 transfer
   }
 
-  if (erc721TransferData && BigNumber.from(value).eq(0)) {
+  if (erc721TransferData && BigNumber.from(value).isZero()) {
     return {
       type: TransactionType.transferCollectible,
       id,
@@ -107,7 +107,7 @@ export const decodeSingle = async (
         abi,
         functionSignature: fragment.format(),
         inputValues: decodeArgs(data, fragment.inputs),
-        value: BigNumber.from(value || '0x0').toString(),
+        value: BigNumber.from(value || '0x00').toString(),
       }
     }
   }
@@ -116,7 +116,7 @@ export const decodeSingle = async (
     type: TransactionType.raw,
     id,
     to,
-    value: BigNumber.from(value || '0x0').toString(),
+    value: BigNumber.from(value || '0x00').toString(),
     data,
   }
 }

--- a/src/encodeMulti.ts
+++ b/src/encodeMulti.ts
@@ -45,7 +45,7 @@ export const encodeMulti = (
   return {
     operation: OperationType.DelegateCall,
     to: multiSendContractAddress || MULTI_SEND_CONTRACT_ADDRESS,
-    value: '0',
+    value: '0x00',
     data,
   }
 }

--- a/src/encodeSingle.ts
+++ b/src/encodeSingle.ts
@@ -55,26 +55,26 @@ export const encodeSingle = (tx: TransactionInput): MetaTransaction => {
         // transfer ERC20 token
         return {
           to: tx.token,
-          value: '0',
+          value: '0x0',
           data: encodeErc20Transfer(tx),
         }
       }
     case TransactionType.transferCollectible:
       return {
         to: tx.address,
-        value: '0',
+        value: '0x0',
         data: encodeErc721Transfer(tx),
       }
     case TransactionType.callContract:
       return {
         to: tx.to,
-        value: tx.value || '0',
+        value: tx.value || '0x0',
         data: encodeFunctionCall(tx),
       }
     case TransactionType.raw:
       return {
         to: tx.to,
-        value: tx.value || '0',
+        value: tx.value || '0x0',
         data: tx.data || '0x',
       }
   }

--- a/src/encodeSingle.ts
+++ b/src/encodeSingle.ts
@@ -50,33 +50,33 @@ export const encodeSingle = (tx: TransactionInput): MetaTransaction => {
         return {
           to: tx.to,
           value: parseEther(tx.amount).toHexString(),
-          data: '0x',
+          data: '0x00',
         }
       } else {
         // transfer ERC20 token
         return {
           to: tx.token,
-          value: '0x0',
+          value: '0x00',
           data: encodeErc20Transfer(tx),
         }
       }
     case TransactionType.transferCollectible:
       return {
         to: tx.address,
-        value: '0x0',
+        value: '0x00',
         data: encodeErc721Transfer(tx),
       }
     case TransactionType.callContract:
       return {
         to: tx.to,
-        value: BigNumber.from(tx.value || '0x0').toHexString(),
+        value: BigNumber.from(tx.value || '0x00').toHexString(),
         data: encodeFunctionCall(tx),
       }
     case TransactionType.raw:
       return {
         to: tx.to,
-        value: BigNumber.from(tx.value || '0x0').toHexString(),
-        data: tx.data || '0x',
+        value: BigNumber.from(tx.value || '0x00').toHexString(),
+        data: tx.data || '0x00',
       }
   }
 }

--- a/src/encodeSingle.ts
+++ b/src/encodeSingle.ts
@@ -1,4 +1,5 @@
 import { AbiCoder, Interface, ParamType } from '@ethersproject/abi'
+import { BigNumber } from '@ethersproject/bignumber'
 import { parseEther, parseUnits } from '@ethersproject/units'
 
 import {
@@ -48,7 +49,7 @@ export const encodeSingle = (tx: TransactionInput): MetaTransaction => {
         // transfer ETH
         return {
           to: tx.to,
-          value: parseEther(tx.amount).toString(),
+          value: parseEther(tx.amount).toHexString(),
           data: '0x',
         }
       } else {
@@ -68,13 +69,13 @@ export const encodeSingle = (tx: TransactionInput): MetaTransaction => {
     case TransactionType.callContract:
       return {
         to: tx.to,
-        value: tx.value || '0x0',
+        value: BigNumber.from(tx.value || '0x0').toHexString(),
         data: encodeFunctionCall(tx),
       }
     case TransactionType.raw:
       return {
         to: tx.to,
-        value: tx.value || '0x0',
+        value: BigNumber.from(tx.value || '0x0').toHexString(),
         data: tx.data || '0x',
       }
   }

--- a/test/decodeMulti.spec.ts
+++ b/test/decodeMulti.spec.ts
@@ -15,13 +15,13 @@ describe('decodeMulti', () => {
       {
         operation: OperationType.Call,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
-        value: BigNumber.from(10).pow(18).toString(),
-        data: '0x',
+        value: BigNumber.from(10).pow(18).toHexString(),
+        data: '0x00',
       },
       {
         operation: OperationType.Call,
         to: '0x36F4BFC9f49Dc5D4b2d10c4a48a6b30128BD79bC',
-        value: '0',
+        value: '0x00',
         data: ercTransferData,
       },
     ]
@@ -35,8 +35,8 @@ describe('decodeMulti', () => {
       {
         operation: OperationType.DelegateCall,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
-        value: '0',
-        data: '0x',
+        value: '0x00',
+        data: '0x00',
       },
     ]
     const multiSendTx = encodeMulti(input)

--- a/test/decodeSingle.spec.ts
+++ b/test/decodeSingle.spec.ts
@@ -16,7 +16,7 @@ describe('decodeSingle', () => {
         operation: 0,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
         value: BigNumber.from(10).pow(18).toHexString(),
-        data: '0x',
+        data: '0x00',
       },
       provider
     )
@@ -42,7 +42,7 @@ describe('decodeSingle', () => {
       {
         operation: 0,
         to: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-        value: '0x0',
+        value: '0x00',
         data: ercTransferData,
       },
       provider
@@ -104,7 +104,7 @@ describe('decodeSingle', () => {
           ['1', '2'],
           ['3', '4'],
         ],
-        [hexZeroPad('0x0', 8), true],
+        [hexZeroPad('0x00', 8), true],
       ]
     )
     const abi = InputsLoggerContract.interface.format(
@@ -181,13 +181,13 @@ describe('decodeSingle', () => {
           ['1', '2'],
           ['3', '4'],
         ],
-        [hexZeroPad('0x0', 8), true],
+        [hexZeroPad('0x00', 8), true],
       ]
     )
     const result = await decodeSingle(
       {
         to: '0x36F4BFC9f49Dc5D4b2d10c4a48a6b30128BD79bC',
-        value: '0x0',
+        value: '0x00',
         data,
       },
       provider
@@ -207,7 +207,7 @@ describe('decodeSingle', () => {
         operation: 0,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
         value: BigNumber.from(10).pow(18).toHexString(),
-        data: '0x',
+        data: '0x00',
       },
       provider,
       undefined,

--- a/test/decodeSingle.spec.ts
+++ b/test/decodeSingle.spec.ts
@@ -15,7 +15,7 @@ describe('decodeSingle', () => {
       {
         operation: 0,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
-        value: BigNumber.from(10).pow(18).toString(),
+        value: BigNumber.from(10).pow(18).toHexString(),
         data: '0x',
       },
       provider
@@ -42,7 +42,7 @@ describe('decodeSingle', () => {
       {
         operation: 0,
         to: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-        value: '0',
+        value: '0x0',
         data: ercTransferData,
       },
       provider
@@ -187,7 +187,7 @@ describe('decodeSingle', () => {
     const result = await decodeSingle(
       {
         to: '0x36F4BFC9f49Dc5D4b2d10c4a48a6b30128BD79bC',
-        value: '0',
+        value: '0x0',
         data,
       },
       provider
@@ -206,7 +206,7 @@ describe('decodeSingle', () => {
       {
         operation: 0,
         to: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
-        value: BigNumber.from(10).pow(18).toString(),
+        value: BigNumber.from(10).pow(18).toHexString(),
         data: '0x',
       },
       provider,
@@ -214,5 +214,17 @@ describe('decodeSingle', () => {
       'myId'
     )
     expect(txInput.id).to.equal('myId')
+  })
+
+  it('should decode the value to decimal', async () => {
+    const result = await decodeSingle(
+      {
+        to: '0x36F4BFC9f49Dc5D4b2d10c4a48a6b30128BD79bC',
+        value: '0xFF',
+        data: '0x012345678',
+      },
+      provider
+    )
+    expect(result).to.have.property('value', '255')
   })
 })

--- a/test/encodeMulti.spec.ts
+++ b/test/encodeMulti.spec.ts
@@ -39,12 +39,12 @@ describe('encodeMulti', () => {
         {
           to: firstRecipient.address,
           value: BigNumber.from(10).pow(18).toString(),
-          data: '0x',
+          data: '0x00',
         },
         {
           to: secondRecipient.address,
           value: BigNumber.from(10).pow(18).mul(2).toString(),
-          data: '0x',
+          data: '0x00',
         },
       ],
       multiSendContract.address
@@ -111,7 +111,7 @@ describe('encodeMulti', () => {
         {
           to: firstRecipient.address,
           value: BigNumber.from(10).pow(18).toString(),
-          data: '0x',
+          data: '0x00',
         },
       ],
       multiSendContract.address
@@ -128,7 +128,7 @@ describe('encodeMulti', () => {
         {
           to: secondRecipient.address,
           value: BigNumber.from(10).pow(18).mul(2).toString(),
-          data: '0x',
+          data: '0x00',
         },
       ],
       multiSendContract.address

--- a/test/encodeSingle.spec.ts
+++ b/test/encodeSingle.spec.ts
@@ -123,7 +123,7 @@ describe('encodeSingle', () => {
           ['1', '2'],
           ['3', '4'],
         ],
-        tupleParam: { bytesMember: hexZeroPad('0x0', 8), boolMember: true },
+        tupleParam: { bytesMember: hexZeroPad('0x00', 8), boolMember: true },
       },
       id: '',
     })
@@ -192,7 +192,7 @@ describe('encodeSingle', () => {
         type: TransactionType.raw,
         to: testToken.address,
         value: '',
-        data: '0x0',
+        data: '0x00',
         id: '',
       }).value
     ).to.equal('0x00')

--- a/test/encodeSingle.spec.ts
+++ b/test/encodeSingle.spec.ts
@@ -185,4 +185,16 @@ describe('encodeSingle', () => {
       BigNumber.from(10).pow(18)
     )
   })
+
+  it('should encode value in hex', () => {
+    expect(
+      encodeSingle({
+        type: TransactionType.raw,
+        to: testToken.address,
+        value: '',
+        data: '0x0',
+        id: '',
+      }).value
+    ).to.equal('0x00')
+  })
 })

--- a/test/isValid.spec.ts
+++ b/test/isValid.spec.ts
@@ -17,7 +17,7 @@ describe('isValid', () => {
   it('should return true only if the `to` field is a valid address', () => {
     const txWithEmptyTo = {
       ...createTransaction(TransactionType.raw),
-      data: '0x0',
+      data: '0x00',
     }
     expect(isValid(txWithEmptyTo)).to.equal(false)
     expect(


### PR DESCRIPTION
This PR ensures that the encoding produced by `encodeSingle` / `encodeMulti` matches the Ethereum [hex value encoding conventions](https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-encoding)