### PR TITLE
Store inputValues in array instead of object to support unnamed params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethers-multisend",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "A package for crafting multi-send transaction from a Zodiac Avatar, such as a Gnosis Safe, based on ethers.js",
   "main": "build/cjs/index.js",
   "typings": "build/cjs/index.d.ts",

--- a/src/decodeSingle.ts
+++ b/src/decodeSingle.ts
@@ -137,10 +137,5 @@ const abiCoder = new AbiCoder((name: string, value: unknown) => {
 
 const decodeArgs = (data: string, inputs: ParamType[]) => {
   const result = abiCoder.decode(inputs, '0x' + data.substring(10))
-
-  const keys = Object.keys(result)
-  const namedKeys = keys.filter((key) => `${parseInt(key)}` !== key)
-  const allArgsHaveNames = namedKeys.length * 2 === keys.length
-  const keysToUse = allArgsHaveNames ? namedKeys : keys
-  return Object.assign({}, ...keysToUse.map((key) => ({ [key]: result[key] })))
+  return [...result] // turn result (array with named keys) into a plain array
 }

--- a/src/encodeSingle.ts
+++ b/src/encodeSingle.ts
@@ -37,7 +37,7 @@ const defaultValue = (paramType: ParamType) =>
 const encodeFunctionCall = (tx: CallContractTransactionInput) => {
   const iface = new Interface(tx.abi)
   const values = iface.functions[tx.functionSignature].inputs.map(
-    (input) => tx.inputValues[input.name] || defaultValue(input)
+    (input, index) => tx.inputValues[index] || defaultValue(input)
   )
   return iface.encodeFunctionData(tx.functionSignature, values)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface CallContractTransactionInput {
   value: string // amount of wei to send
   abi: string // ABI as JSON string
   functionSignature: string
-  inputValues: { [key: string]: ValueType }
+  inputValues: ValueType[]
 }
 
 export interface TransferFundsTransactionInput {

--- a/test/decodeSingle.spec.ts
+++ b/test/decodeSingle.spec.ts
@@ -130,18 +130,18 @@ describe('decodeSingle', () => {
       abi,
       functionSignature:
         'logInputs(string,address[2],int256[][],(bytes8,bool))',
-      inputValues: {
-        stringParam: 'test',
-        fixedSizeAddressArrayParam: [
+      inputValues: [
+        'test',
+        [
           '0xfF6D102f7A5b52B6A2b654a048b0bA650bE90c59',
           '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
         ],
-        int2DArrayParam: [
+        [
           ['1', '2'],
           ['3', '4'],
         ],
-        tupleParam: ['0x0000000000000000', true],
-      },
+        ['0x0000000000000000', true],
+      ],
       value: '0',
     })
   })

--- a/test/encodeSingle.spec.ts
+++ b/test/encodeSingle.spec.ts
@@ -116,15 +116,15 @@ describe('encodeSingle', () => {
       value: '',
       functionSignature:
         'logInputs(string,address[2],int256[][],(bytes8,bool))',
-      inputValues: {
-        stringParam: 'test',
-        fixedSizeAddressArrayParam: [testToken.address, testNft.address],
-        int2DArrayParam: [
+      inputValues: [
+        'test',
+        [testToken.address, testNft.address],
+        [
           ['1', '2'],
           ['3', '4'],
         ],
-        tupleParam: { bytesMember: hexZeroPad('0x00', 8), boolMember: true },
-      },
+        { bytesMember: hexZeroPad('0x00', 8), boolMember: true },
+      ],
       id: '',
     })
 
@@ -145,7 +145,7 @@ describe('encodeSingle', () => {
       abi: inputsLogger.interface.format(FormatTypes.json) as string,
       value: '',
       functionSignature: 'logInputs(string,address[2])',
-      inputValues: {},
+      inputValues: [],
       id: '',
     })
 


### PR DESCRIPTION
BREAKING CHANGE: `CallContractTransactionInput.inputValues` is now an array rather than an object